### PR TITLE
operator [], whole List interface (with iteration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Files and directories created by pub
 .dart_tool/
+.idea/
 .packages
 .pub/
 build/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # dart-circularbuffer
 A circular buffer container for Dart
+
+Supports all [List] operations!

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,14 +1,14 @@
 import 'package:circular_buffer/circular_buffer.dart';
 
 main() async {
-  CircularBuffer<int> cb = new CircularBuffer<int>(5);
+  CircularBuffer<int> cb = new CircularBuffer(5);
 
   List<int> L = [4, 5, 1, -3, 8, 2, 6, 7, 4, 5];
   int sum = 0;
   double mean;
   for (int a in L) {
     int first = cb.isFilled ? cb.first : 0;
-    await cb.insert(a);
+    cb.add(a);
     sum += cb.last - first;
 
     mean = sum.toDouble() / cb.length;

--- a/lib/circular_buffer.dart
+++ b/lib/circular_buffer.dart
@@ -1,4 +1,7 @@
-class CircularBuffer<T> {
+import 'dart:collection';
+
+/// Supports all [List] operations
+class CircularBuffer<T> with ListMixin<T> {
   List<T> _buf;
   int _start;
   int _end;
@@ -15,8 +18,8 @@ class CircularBuffer<T> {
     _count = 0;
   }
 
-  insert(T el) async {
-    // Inserting the next value
+  void add(T el) {
+    // Adding the next value
     _end++;
     if (_end == _buf.length) {
       _end = 0;
@@ -35,43 +38,28 @@ class CircularBuffer<T> {
     }
   }
 
-  @Deprecated("Use `first` instead")
-  T get start => _buf[_start];
-  @Deprecated("Use `last` instead")
-  T get end => _buf[_end];
-
-  /// Element at the start of the [CircularBuffer]
-  T get first => _buf[_start];
-
-  /// Element at the end of the [CircularBuffer]
-  T get last => _buf[_end];
-
-  @Deprecated("Use `length` instead")
-  int get len => _count;
-  @Deprecated("Use `capacity` instead")
-  int get cap => _buf.length;
-
   /// Number of elements of [CircularBuffer]
   int get length => _count;
 
-  /// Maximun number of elements of [CircularBuffer]
+  /// Maximum number of elements of [CircularBuffer]
   int get capacity => _buf.length;
-
-  @Deprecated("Use `isFilled` instead")
-  bool get filled => (_count == _buf.length);
-  @Deprecated("Use `isUnfilled` instead")
-  bool get unfilled => (_count < _buf.length);
 
   bool get isFilled => (_count == _buf.length);
   bool get isUnfilled => (_count < _buf.length);
 
-  /// Allows you to iterate over the contents of the buffer
-  /// The [action] callback is called for each item in the
-  /// buffer.
-  void forEach(void Function(T) action) {
-    for (var i = _start; i < _start + _count; i++) {
-      var val = _buf[i % len];
-      action(val);
-    }
+  T operator [] (int index) {
+    if(index > _count) throw RangeError.index(index, this);
+
+    return _buf[(_start + index) % _buf.length];
+  }
+
+  void operator []= (int index, T value) {
+    if(index > _count) throw RangeError.index(index, this);
+
+    _buf[(_start + index) % _buf.length] = value;
+  }
+
+  set length(int newLength) {
+    throw new UnsupportedError("Cannot resize immutable CircularBuffer.");
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: circular_buffer
-version: 0.6.0
+version: 0.7.0
 description: A Dart Circular Buffer container
 homepage: http://www.github.com/kranfix/dart-circularbuffer
 documentation: http://www.github.com/kranfix/dart-circularbuffer#readme


### PR DESCRIPTION
HIGHLY INCOMPATIBLE (that's why I bumped version to 0.7.0)!
- adds whole List compatibility like indexing and iteration
- renames `insert` to `add` for List compatibility
- removes deprecated properties like `cap`, `len`, `start`, `end`, `filled` and `unfilled` (`capacity`, `length`, `first`, `last`, `isFilled` and `isUnfilled` should be used instead) - why not as we already did pretty breaking changes?

PS. `first`, `last` and `forEach` is not deleted, it's now handled by ListMixin based on `operator []`

Closes #3, closes #4 