### PR TITLE
Migrate package to null safety

### DIFF
--- a/lib/circular_buffer.dart
+++ b/lib/circular_buffer.dart
@@ -4,12 +4,12 @@ import 'dart:collection';
 class CircularBuffer<T> with ListMixin<T> {
   /// Creates a [CircularBuffer] with a `capacity`
   CircularBuffer(int capacity)
-      : assert(capacity != null && capacity > 1),
-        _buf = List<T>(capacity) {
-    reset();
-  }
+      : assert(capacity > 1),
+        _capacity = capacity,
+        _buf = [];
 
   final List<T> _buf;
+  final int _capacity;
   int _start = 0;
   int _end = -1;
   int _count = 0;
@@ -25,13 +25,13 @@ class CircularBuffer<T> with ListMixin<T> {
   void add(T element) {
     // Adding the next value
     _end++;
-    if (_end == _buf.length) {
+    if (_end == _capacity) {
       _end = 0;
     }
-    _buf[_end] = element;
-
-    // updating the start
-    if (_count < _buf.length) {
+    if (isFilled) {
+      _buf[_end] = element;
+    } else {
+      _buf.add(element);
       _count++;
       return;
     }
@@ -47,20 +47,20 @@ class CircularBuffer<T> with ListMixin<T> {
   int get length => _count;
 
   /// Maximum number of elements of [CircularBuffer]
-  int get capacity => _buf.length;
+  int get capacity => _capacity;
 
   /// The [CircularBuffer] `isFilled`  if the `length`
   /// is equal to the `capacity`
-  bool get isFilled => (_count == _buf.length);
+  bool get isFilled => (_count == _capacity);
 
   /// The [CircularBuffer] `isUnfilled`  if the `length` is
   /// is less than the `capacity`
-  bool get isUnfilled => (_count < _buf.length);
+  bool get isUnfilled => (_count < _capacity);
 
   @override
   T operator [](int index) {
     if (index >= 0 && index < _count) {
-      return _buf[(_start + index) % _buf.length];
+      return _buf[(_start + index) % _buf.length]!;
     }
     throw RangeError.index(index, this);
   }
@@ -69,8 +69,9 @@ class CircularBuffer<T> with ListMixin<T> {
   void operator []=(int index, T value) {
     if (index >= 0 && index < _count) {
       _buf[(_start + index) % _buf.length] = value;
+    } else {
+      throw RangeError.index(index, this);
     }
-    throw RangeError.index(index, this);
   }
 
   /// The `length` mutation is forbidden

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,9 +4,8 @@ description: A Dart Circular Buffer container
 homepage: https://www.github.com/kranfix/dart-circularbuffer
 documentation: https://www.github.com/kranfix/dart-circularbuffer#readme
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  coverage: ^0.14.1
-  pedantic: ^1.9.0
-  test: ^1.14.6
+  pedantic: ^1.10.0
+  test: ^1.16.4

--- a/test/circular_buffer_test.dart
+++ b/test/circular_buffer_test.dart
@@ -3,12 +3,6 @@ import 'package:test/test.dart';
 
 void main() {
   group('Creating a CircularBuffer', () {
-    test('with null capacity throws an error', () {
-      expect(() {
-        CircularBuffer<int>(null);
-      }, throwsA(isA<AssertionError>()));
-    });
-
     test('with zero or one element capacity', () {
       expect(() {
         CircularBuffer<int>(0);


### PR DESCRIPTION
Hi there,

I am a user of your package and I thought I'd help out by migrating to null safety for you.

It'll still need a version bump.

This needed some small modifications because the `List<E>(int)` constructor is no longer available. Instead, we create an empty list and grow it up to capacity, at which point we switch over to overwriting elements.

I also had to remove the dependency on the coverage package, because it is not null safe yet (but looks like it will be shortly, based on this commit https://github.com/dart-lang/coverage/commit/85141b7ba4dc3d715865e689926bef034aa85548).

All tests are passing.