### PR TITLE
Simplify the CircularBuffer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.11.0
+
+- Made `clear` work.
+
+- Fixed to work with nullable element types.
+
+- Simplified the implementation.
+
 # 0.10.0+1
 
 - Corrected examples in documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.11.0
 
-- Made `clear` work.
+- Fixed incorrect buffer state when adding items after calling `reset`.
+
+- Made `clear` be an alias to `reset` instead of throwing an error.
 
 - Fixed to work with nullable element types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,35 @@
+# 0.10.0+1
+
+- Corrected examples in documentation.
+
 # 0.10.0 - 2021-08-13
 
-- Adding constructtor `CircularBuffer.of(List<T> list, [int? capacity])`.
+- Added a `CircularBuffer.of(List<T> list, [int? capacity])` constructor.
 
 # 0.9.1
 
-- Adding documentation to `CircularBuffer` class
-- Adding example to README
+- Added documentation to `CircularBuffer` class
+- Added example to README
 
 # 0.9.0
 
-- Migrating to null-safety (Thanks to @shyndman)
-- Adding test for border conditions
+- Migrated to null-safety (thanks to @shyndman)
+- Added test for border conditions
 
 # 0.8.0
 
-- The `CircularBuffer` mininum capacity is 2
-- Adding tests
+- The `CircularBuffer` minimum capacity is 2
+- Added tests
 
 # 0.7.0
 
-- `CircularBuffer` support ListMixin
+- Use `ListMixin`.
 
 # 0.6.0
 
 - Migration to Dart 2.
-- Aadding forEach method.
+- Added forEach method.
 
 # 0.5.0
 
-- A circular buffer made in dart 1.
+- A circular buffer made in Dart 1.

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ print(buffer.isFilled); // true
 print(buffer.isUnfilled); // false
 
 buffer.add(4);
-print(buffer.first); // 4
+print(buffer.first); // 2
 ```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    require_trailing_commas: false

--- a/lib/circular_buffer.dart
+++ b/lib/circular_buffer.dart
@@ -15,7 +15,7 @@ import 'dart:collection';
 /// print(buffer.isUnfilled); // false
 ///
 /// buffer.add(4);
-/// print(buffer.first); // 4
+/// print(buffer.first); // 2
 /// ```
 class CircularBuffer<T> with ListMixin<T> {
   /// Creates a [CircularBuffer] with a `capacity`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: circular_buffer
-version: 0.10.0+1
+version: 0.11.0
 description: >
   A Dart Circular Buffer container based on List with a fixed capacity.
 homepage: https://www.github.com/kranfix/dart-circularbuffer
@@ -10,4 +10,3 @@ environment:
 dev_dependencies:
   test: ^1.16.4
   very_good_analysis: ^2.3.0
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: circular_buffer
-version: 0.10.0
+version: 0.10.0+1
 description: >
   A Dart Circular Buffer container based on List with a fixed capacity.
 homepage: https://www.github.com/kranfix/dart-circularbuffer

--- a/test/circular_buffer_test.dart
+++ b/test/circular_buffer_test.dart
@@ -214,14 +214,28 @@ void main() {
     expect(collectedList3, expectedList3);
   });
 
-  test('when is reset', () {
-    final buffer = CircularBuffer<int>(5)
-      ..add(1)
-      ..add(2)
-      ..reset();
+  group('resetting', () {
+    test('when is reset', () {
+      final buffer = CircularBuffer<int>(5)
+        ..add(1)
+        ..add(2)
+        ..reset();
 
-    expect(buffer.length, 0);
-    expect(buffer.capacity, 5);
+      expect(buffer.length, 0);
+      expect(buffer.capacity, 5);
+    });
+
+    test('adding items after a reset', () {
+      final buffer = CircularBuffer<int>(5)
+        ..add(1)
+        ..add(2)
+        ..reset()
+        ..add(3)
+        ..add(4);
+
+      expect(buffer, [3, 4]);
+      expect(buffer.capacity, 5);
+    });
   });
 
   test('Editing a value with a given index', () {

--- a/test/circular_buffer_test.dart
+++ b/test/circular_buffer_test.dart
@@ -269,4 +269,9 @@ void main() {
       expect(buffer.first, 4);
     });
   });
+
+  test('nullable elements', () {
+    final buffer = CircularBuffer<int?>(3)..add(null)..add(2);
+    expect(buffer, <int?>[null, 2]);
+  });
 }


### PR DESCRIPTION
Simplify the `CircularBuffer` implementation:

* Merge the `_capacity` private member variable and the `capacity`
  getter into a public `final` member variable.

* `_count` is redundant.  It currently should always be the same as
  `_buf.length`[1].

* `_end` is redundant and can always be determined from `_start` and
  `_buf.length`.

Additionally:

* Made `clear()` work.

* Suppress the `require_trailing_commas` lint, which is enabled in
  current versions of `package:very_good_analysis`. (Satisfying the
  lint right now would result in many changes that I do not want to
  be part of this change.)

* Fix complaints from the linter about `assert`s without messages.

* Fix an incorrect use of the null-assertion operator.  It's
  unnecessary, and it will incorrectly throw an exception if the
  `CircularBuffer` legitimately stores `null` elements.

[1] `_count` does not necessarily *need* to be the same as
    `_buf.length`.  In principle, `_count` could be allowed to be
    less than `_buf.length`, and `CircularBuffer` could allow the
    appearance of removing elements without resizing `_buf`.  I
    considered implementing that, but the `CircularBuffer` would
    retain references to the "removed" elements and unexpectedly
    would prevent them from being garbage-collected.  This could be
    solved by changing `_buf` from a `List<T>` to a `List<T?>` and
    adding an `as T` cast to `operator []`.  That can be work left
    for another day if there's demand for it.
